### PR TITLE
also take json policies/schemas integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ This repository contains integration tests for the Cedar policy language. It is 
 
 An integration test is a JSON file with the following fields:
 
-* `policies`: The name of the Cedar policy file (`*.cedar`)
+* `policies`: The name of the policy file
+* `policyFormat`: Format of the policy file: `cedar` (default) or `json`. If absent, defaults to `cedar`.
 * `entities`: The name of the entities file (`*.entities.json`)
-* `schema`: The name of the Cedar schema file (`*.cedarschema`)
+* `schema`: The name of the schema file
+* `schemaFormat`: Format of the schema file: `cedar` (default) or `json`. If absent, defaults to `cedar`.
 * `shouldValidate`: Whether the policy validate using the schema (true/false)
 * `requests`: Sequence of authorization requests and expected results (see below)
 

--- a/tests/example_use_cases/2a_json_policy.json
+++ b/tests/example_use_cases/2a_json_policy.json
@@ -1,0 +1,57 @@
+{
+ "policies": "tests/example_use_cases/policies_2a.cedar.json",
+ "policyFormat": "json",
+ "entities": "sample-data/sandbox_a/entities.json",
+ "schema": "sample-data/sandbox_a/schema.cedarschema",
+ "shouldValidate": true,
+ "requests": [
+  {
+   "description": "alice should be able to view the photo (json policy format)",
+   "principal": {
+    "type": "User",
+    "id": "alice"
+   },
+   "action": {
+    "type": "Action",
+    "id": "view"
+   },
+   "resource": {
+    "type": "Photo",
+    "id": "VacationPhoto94.jpg"
+   },
+   "context": {
+    "source_ip": "123.123.123.123",
+    "confidence_score": "0.6",
+    "authenticated": true
+   },
+   "decision": "allow",
+   "reason": [
+    "policy0"
+   ],
+   "errors": []
+  },
+  {
+   "description": "bob should not be allowed to view the photo (json policy format)",
+   "principal": {
+    "type": "User",
+    "id": "bob"
+   },
+   "action": {
+    "type": "Action",
+    "id": "view"
+   },
+   "resource": {
+    "type": "Photo",
+    "id": "VacationPhoto94.jpg"
+   },
+   "context": {
+    "source_ip": "123.123.123.123",
+    "confidence_score": "0.6",
+    "authenticated": true
+   },
+   "decision": "deny",
+   "reason": [],
+   "errors": []
+  }
+ ]
+}

--- a/tests/example_use_cases/2a_json_schema.json
+++ b/tests/example_use_cases/2a_json_schema.json
@@ -1,0 +1,57 @@
+{
+ "policies": "tests/example_use_cases/policies_2a.cedar",
+ "entities": "sample-data/sandbox_a/entities.json",
+ "schema": "tests/example_use_cases/schema_2a.json",
+ "schemaFormat": "json",
+ "shouldValidate": true,
+ "requests": [
+  {
+   "description": "alice should be able to view the photo (json schema format)",
+   "principal": {
+    "type": "User",
+    "id": "alice"
+   },
+   "action": {
+    "type": "Action",
+    "id": "view"
+   },
+   "resource": {
+    "type": "Photo",
+    "id": "VacationPhoto94.jpg"
+   },
+   "context": {
+    "source_ip": "123.123.123.123",
+    "confidence_score": "0.6",
+    "authenticated": true
+   },
+   "decision": "allow",
+   "reason": [
+    "policy0"
+   ],
+   "errors": []
+  },
+  {
+   "description": "bob should not be allowed to view the photo (json schema format)",
+   "principal": {
+    "type": "User",
+    "id": "bob"
+   },
+   "action": {
+    "type": "Action",
+    "id": "view"
+   },
+   "resource": {
+    "type": "Photo",
+    "id": "VacationPhoto94.jpg"
+   },
+   "context": {
+    "source_ip": "123.123.123.123",
+    "confidence_score": "0.6",
+    "authenticated": true
+   },
+   "decision": "deny",
+   "reason": [],
+   "errors": []
+  }
+ ]
+}

--- a/tests/example_use_cases/policies_2a.cedar.json
+++ b/tests/example_use_cases/policies_2a.cedar.json
@@ -1,0 +1,1 @@
+{"templates":{},"staticPolicies":{"policy0":{"effect":"permit","principal":{"op":"in","entity":{"type":"UserGroup","id":"jane_friends"}},"action":{"op":"==","entity":{"type":"Action","id":"view"}},"resource":{"op":"==","entity":{"type":"Photo","id":"VacationPhoto94.jpg"}},"conditions":[]}},"templateLinks":[]}

--- a/tests/example_use_cases/schema_2a.json
+++ b/tests/example_use_cases/schema_2a.json
@@ -1,0 +1,226 @@
+{
+    "": {
+        "entityTypes": {
+            "Account": {},
+            "AccountGroup": {},
+            "Administrator": {},
+            "Album": {
+                "memberOfTypes": [
+                    "Account",
+                    "Album"
+                ]
+            },
+            "Photo": {
+                "memberOfTypes": [
+                    "Account",
+                    "Album"
+                ]
+            },
+            "User": {
+                "memberOfTypes": [
+                    "UserGroup"
+                ]
+            },
+            "UserGroup": {},
+            "Video": {
+                "memberOfTypes": [
+                    "Account",
+                    "Album"
+                ]
+            }
+        },
+        "actions": {
+            "addPhoto": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Album"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ],
+                    "context": {
+                        "type": "Record",
+                        "attributes": {
+                            "authenticated": {
+                                "type": "EntityOrCommon",
+                                "name": "Bool"
+                            },
+                            "confidence_score": {
+                                "type": "EntityOrCommon",
+                                "name": "decimal"
+                            },
+                            "source_ip": {
+                                "type": "EntityOrCommon",
+                                "name": "ipaddr"
+                            }
+                        }
+                    }
+                }
+            },
+            "comment": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Photo"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ],
+                    "context": {
+                        "type": "Record",
+                        "attributes": {
+                            "authenticated": {
+                                "type": "EntityOrCommon",
+                                "name": "Bool"
+                            },
+                            "confidence_score": {
+                                "type": "EntityOrCommon",
+                                "name": "decimal"
+                            },
+                            "source_ip": {
+                                "type": "EntityOrCommon",
+                                "name": "ipaddr"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Photo"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ],
+                    "context": {
+                        "type": "Record",
+                        "attributes": {
+                            "authenticated": {
+                                "type": "EntityOrCommon",
+                                "name": "Bool"
+                            },
+                            "confidence_score": {
+                                "type": "EntityOrCommon",
+                                "name": "decimal"
+                            },
+                            "source_ip": {
+                                "type": "EntityOrCommon",
+                                "name": "ipaddr"
+                            }
+                        }
+                    }
+                }
+            },
+            "edit": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Photo"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ],
+                    "context": {
+                        "type": "Record",
+                        "attributes": {
+                            "authenticated": {
+                                "type": "EntityOrCommon",
+                                "name": "Bool"
+                            },
+                            "confidence_score": {
+                                "type": "EntityOrCommon",
+                                "name": "decimal"
+                            },
+                            "source_ip": {
+                                "type": "EntityOrCommon",
+                                "name": "ipaddr"
+                            }
+                        }
+                    }
+                }
+            },
+            "listAlbums": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Account"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ],
+                    "context": {
+                        "type": "Record",
+                        "attributes": {
+                            "authenticated": {
+                                "type": "EntityOrCommon",
+                                "name": "Bool"
+                            },
+                            "confidence_score": {
+                                "type": "EntityOrCommon",
+                                "name": "decimal"
+                            },
+                            "source_ip": {
+                                "type": "EntityOrCommon",
+                                "name": "ipaddr"
+                            }
+                        }
+                    }
+                }
+            },
+            "listPhotos": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Album"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ],
+                    "context": {
+                        "type": "Record",
+                        "attributes": {
+                            "authenticated": {
+                                "type": "EntityOrCommon",
+                                "name": "Bool"
+                            },
+                            "confidence_score": {
+                                "type": "EntityOrCommon",
+                                "name": "decimal"
+                            },
+                            "source_ip": {
+                                "type": "EntityOrCommon",
+                                "name": "ipaddr"
+                            }
+                        }
+                    }
+                }
+            },
+            "view": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Photo",
+                        "Video"
+                    ],
+                    "principalTypes": [
+                        "User",
+                        "Administrator"
+                    ],
+                    "context": {
+                        "type": "Record",
+                        "attributes": {
+                            "authenticated": {
+                                "type": "EntityOrCommon",
+                                "name": "Bool"
+                            },
+                            "confidence_score": {
+                                "type": "EntityOrCommon",
+                                "name": "decimal"
+                            },
+                            "source_ip": {
+                                "type": "EntityOrCommon",
+                                "name": "ipaddr"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds sample integration tests using the json format for policies or schemas. Specifying the `schemaFormat` or the `policiesFormat` is optional, and when not specified the format should be assumed to be human-readable Cedar syntax.
The corresponding changes in the Rust cedar testing are here: https://github.com/cedar-policy/cedar/pull/2334